### PR TITLE
Updates for smoother development

### DIFF
--- a/core/src/base-plugin.ts
+++ b/core/src/base-plugin.ts
@@ -158,6 +158,10 @@ export abstract class BasePlugin {
     docker_result.stdout.on('error', processError);
     docker_result.stderr.on('error', processError);
 
+    docker_result.on('error', (error) => {
+      emitter.error(error.message);
+    });
+
     docker_result.on('close', (code) => {
       if (code === 0 && image_digest !== '') {
         emitter.buildOutput(image_digest);

--- a/opentofu/src/plugin.ts
+++ b/opentofu/src/plugin.ts
@@ -79,8 +79,9 @@ export class OpenTofuPlugin extends BasePlugin {
         pulumi_result.stderr?.on('data', processChunk);
         pulumi_result.on('exit', (code) => {
           if (code !== 0) {
-            emitter.error(`${output}\nExited with exit code: ${code}`);
-            reject();
+            const error_message = `${output}\nExited with exit code: ${code}`;
+            emitter.error(error_message);
+            return reject(error_message);
           }
           resolve(code);
         });
@@ -104,6 +105,8 @@ export class OpenTofuPlugin extends BasePlugin {
         }
       }
       emitter.applyOutput(state, outputs);
-    }).catch();
+    }).catch(error => {
+      console.log(error);
+    });
   }
 }

--- a/pulumi/src/plugin.ts
+++ b/pulumi/src/plugin.ts
@@ -95,8 +95,9 @@ export class PulumiPlugin extends BasePlugin {
         pulumi_result.stderr?.on('data', processChunk);
         pulumi_result.on('exit', (code) => {
           if (code !== 0) {
-            emitter.error(`${output}\nExited with exit code: ${code}`);
-            return reject();
+            const error_message = `${output}\nExited with exit code: ${code}`;
+            emitter.error(error_message);
+            return reject(error_message);
           }
           resolve(code);
         });
@@ -116,6 +117,8 @@ export class PulumiPlugin extends BasePlugin {
         outputs = JSON.parse(output_parts[2] || '{}');
       }
       emitter.applyOutput(state, outputs);
-    }).catch();
+    }).catch(error => {
+      console.log(error)
+    });
   }
 }


### PR DESCRIPTION
These changes will prevent the server from crashing if a Pulumi/OpenTofu command fails. Having to restart the server every time it crashes in development is no fun.